### PR TITLE
Update dependencies to latest sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "electron-squirrel-startup": "^1.0.0",
     "express": "4.15.2",
     "socket.io": "^2.3.0",
-    "transbank-pos-sdk": "^0.1.3"
+    "transbank-pos-sdk": "1.1.0"
   }
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -145,11 +145,11 @@ export default class Server {
 
             socket.on('multicodeSale', ({amount, ticket, commerceCode = '0'}) => {
                 pos.multicodeSale(amount, ticket, commerceCode, true, (data) => {
-                    io.emit('sale_status.response', data.split('|'));
+                    io.emit('multicodeSale_status.response', data.split('|'));
                 }).then((response) => {
-                    io.emit('sale.response', { success: true, response});
+                    io.emit('multicodeSale.response', { success: true, response});
                 }).catch((e) => {
-                    io.emit('sale.response', { success: false, message: e.toString()});
+                    io.emit('multicodeSale.response', { success: false, message: e.toString()});
                 })
             });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6901,10 +6901,10 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-transbank-pos-sdk@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/transbank-pos-sdk/-/transbank-pos-sdk-0.1.3.tgz#39dc8a39857af8fa301c558d7b91d5639231e6cb"
-  integrity sha512-iDtP12rNwpONH+TBivxZ3vlk2lh3nU4KZiHeSqIXDPyy47K8a6IzkHcwEsixpoKt1fAwa6hBzThEaUPrtH/5Qg==
+transbank-pos-sdk@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/transbank-pos-sdk/-/transbank-pos-sdk-1.1.0.tgz#47eb99ddc5240293879dd69f0b4fb533a5838afb"
+  integrity sha512-4QTF53mc+5KaLiwhhbDvxuUnOT4ayNOm9c2y6tZzDh8bq4mS6jHHv8C53QZkg4wTmASIZHQuefOx4Y1z5rbRKg==
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@serialport/parser-inter-byte-timeout" "^9.0.1"


### PR DESCRIPTION
- Use the latest node.js SDK that include support for multicode sale