### PR TITLE
Prepare release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [3.0.0] - 25-05-2021
 
-Se mejoran funcionalidades del agente. Funciona con la versión 3.0.0 del [SDK Web](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-js/releases/tag/2.1.0) 
+Se mejoran funcionalidades del agente. Funciona con la versión 3.0.0 del [SDK Web](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-js/releases/tag/3.0.0) 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
-[2.1.0]
-# Added
+## [3.0.0] - 25-05-2021
+
+Se mejoran funcionalidades del agente. Funciona con la versión 3.0.0 del [SDK Web](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-js/releases/tag/2.1.0) 
+
+### Added
+
+- Se agrega la versión en la interfaz del agente.
+- Se añade respuesta para que el SDK web pueda solicitar la versión del agente.
+
+## Changed
+
+- Se cambia la respuesta para los mensajes intermedios, ahora se retorna un objeto.
+- Se modifica la respuesta de las peticiones al agente, ahora se responde al nombre indicado por parámetro en la petición.
+
+## [2.1.0]
+
+### Added
+
 - Primer release oficial. Funciona con la versión 2.1.0 del [SDK Web](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-js/releases/tag/2.1.0) 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "transbank-pos-sdk-web-agent",
   "productName": "Transbank POS Agent",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Agente para SDK Web de POS integrado",
   "main": ".webpack/main",
   "scripts": {


### PR DESCRIPTION
Intermediate messages and agent responses are improved. A request is added to return the version of the agent.

You can see full diff here: https://github.com/TransbankDevelopers/transbank-pos-sdk-web-agent/compare/master...chore/prepare-release-3.0.0